### PR TITLE
Issue #7: move Flask app building from __init__.py to views.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ A REST service based on Flask translates incoming calls to this local API.
 ### Running locally
 For development, you can run the service using Flask:
 
-    export FLASK_APP=openeo_driver/__init__.py
-    export SPARK_HOME=/usr/lib64/python3.6/site-packages/pyspark
-    FLASK_DEBUG=1 flask run
+    export FLASK_APP=openeo_driver.views
+    export FLASK_DEBUG=1 
+    flask run
 
 For production, a gunicorn server script is available:
 
-    PYTHONPATH=. python openeogeotrellis/server.py
+    python openeo_driver/server.py

--- a/openeo_driver/__init__.py
+++ b/openeo_driver/__init__.py
@@ -1,6 +1,1 @@
-from flask import Flask
-app = Flask(__name__)
-app.config['APPLICATION_ROOT'] = '/openeo'
-
-from ._version import __version__
-import openeo_driver.views
+from  openeo_driver._version import __version__

--- a/openeo_driver/server.py
+++ b/openeo_driver/server.py
@@ -1,7 +1,7 @@
 import gunicorn.app.base
 from gunicorn.six import iteritems
 
-from openeo_driver import app
+from openeo_driver.views import app
 
 """
 Script to start a production server. This script can serve as the entry-point for doing spark-submit.

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1,12 +1,10 @@
 import os
 import logging
 from distutils.version import LooseVersion
-from urllib.parse import unquote
 
-from flask import request, url_for, jsonify, send_from_directory, abort, make_response,Blueprint,g, current_app
+from flask import Flask, request, url_for, jsonify, send_from_directory, abort, make_response,Blueprint,g, current_app
 from werkzeug.exceptions import HTTPException, BadRequest, NotFound
 
-from openeo_driver import app
 from openeo_driver.errors import OpenEOApiException, CollectionNotFoundException
 from openeo_driver.save_result import SaveResult
 from .ProcessGraphDeserializer import (evaluate, health_check, get_layers, getProcesses, getProcess, get_layer,
@@ -26,6 +24,11 @@ SUPPORTED_VERSIONS = [
 ]
 DEFAULT_VERSION = '0.3.1'
 
+
+app = Flask(__name__)
+app.config['APPLICATION_ROOT'] = '/openeo'
+
+
 openeo_bp = Blueprint('openeo', __name__)
 
 _log = logging.getLogger('openeo.driver')
@@ -33,7 +36,7 @@ _log = logging.getLogger('openeo.driver')
 @openeo_bp.url_defaults
 def _add_version(endpoint, values):
     """Callback to automatically add "version" argument in `url_for` calls."""
-    if 'version' not in values and app.url_map.is_endpoint_expecting(endpoint, 'version'):
+    if 'version' not in values and current_app.url_map.is_endpoint_expecting(endpoint, 'version'):
         values['version'] = g.get('version', DEFAULT_VERSION)
 
 

--- a/run_debug.sh
+++ b/run_debug.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-SPARK_HOME=$(find_spark_home.py) FLASK_APP=openeo_driver/__init__.py FLASK_DEBUG=1 flask run
+FLASK_APP=openeo_driver.views FLASK_DEBUG=1 flask run

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,7 +31,7 @@ def setup_local_spark():
     pysc = SparkContext.getOrCreate(conf)
 #setup_local_spark()
 
-from openeo_driver import app
+from openeo_driver.views import app
 import json
 import os
 import dummy_impl

--- a/tests/test_views_04x.py
+++ b/tests/test_views_04x.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, skip
 
 from . import load_json_resource
-from openeo_driver import app
+from openeo_driver.views import app
 import json
 import os
 import dummy_impl


### PR DESCRIPTION
addresses #7  by simply moving creation of `app` object from `__init__.py` to `views.py`

Note: all launch scripts have to be updated to use `openeo_driver.views` as FLASK_APP