### PR TITLE
Remove old (POC) endpoints

### DIFF
--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -385,39 +385,6 @@ def me(user: User):
     })
 
 
-@openeo_bp.route('/timeseries')
-def timeseries():
-    # TODO: deprecated? do we still need this endpoint? #35
-    return 'OpenEO GeoPyspark backend. ' + url_for('.point')
-
-
-@openeo_bp.route('/timeseries/point', methods=['POST'])
-def point():
-    # TODO: deprecated? do we still need this endpoint? #35
-    x = float(request.args.get('x', ''))
-    y = float(request.args.get('y', ''))
-    srs = request.args.get('srs', None)
-    process_graph = _extract_process_graph(request.json)
-    image_collection = evaluate(process_graph, env=EvalEnv({'version': g.api_version}))
-    return jsonify(image_collection.timeseries(x, y, srs))
-
-
-@openeo_bp.route('/download', methods=['GET', 'POST'])
-def download():
-    # TODO: deprecated?
-    if request.method == 'POST':
-        outputformat = request.args.get('outputformat', 'geotiff')
-
-        process_graph = request.get_json()
-        image_collection = evaluate(process_graph)
-        # TODO Unify with execute?
-
-        filename = image_collection.save_result(filename=get_temp_file(), format=outputformat, format_options={})
-        return send_from_directory(os.path.dirname(filename), os.path.basename(filename))
-    else:
-        return 'Usage: Download image using POST.'
-
-
 def _extract_process_graph(post_data: dict) -> dict:
     """
     Extract process graph dictionary from POST data

--- a/tests/test_views_execute.py
+++ b/tests/test_views_execute.py
@@ -642,26 +642,6 @@ def test_no_nested_JSONResult(api):
     ).assert_status_code(200).assert_content()
 
 
-def test_timeseries_point_with_bbox(api):
-    process_graph = {
-        "loadcollection1": {
-            'process_id': 'load_collection',
-            'arguments': {'id': 'S2_FAPAR_CLOUDCOVER'},
-        },
-        "filterbbox": {
-            "process_id": "filter_bbox",
-            "arguments": {
-                "data": {"from_node": "loadcollection1"},
-                "extent": {"west": 3, "east": 6, "south": 50, "north": 51, "crs": "EPSG:4326"}
-            },
-            "result": True
-        }
-    }
-    api.check_result(process_graph, path="/timeseries/point?x=1&y=2")
-    params = dummy_backend.last_load_collection_call('S2_FAPAR_CLOUDCOVER')
-    assert params["spatial_extent"] == {"west": 3, "east": 6, "south": 50, "north": 51, "crs": "EPSG:4326"}
-
-
 def test_load_disk_data(api):
     api.check_result("load_disk_data.json")
     params = dummy_backend.last_load_collection_call(


### PR DESCRIPTION
Remove old (POC) endpoints `/timeseries`, `/timeseries/point`, `/download`

@jdries   can we remove these old endpoints or are these still used somewhere internally?

