### PR TITLE
support retrieving job_options inline if not specified separately

### DIFF
--- a/openeo_driver/ProcessGraphDeserializer.py
+++ b/openeo_driver/ProcessGraphDeserializer.py
@@ -1491,6 +1491,13 @@ def apply_process(process_id: str, args: dict, namespace: Union[str, None], env:
         _log.debug(f"data_mask: env.push: {the_mask}")
         env = env.push(data_mask=the_mask)
         args = {"data": convert_node(args["data"], env=env), "mask": the_mask}
+    elif process_id == "if":
+        #special handling: we only want to evaluate the branch that gets accepted
+        value = args.get("value")
+        if convert_node(value, env=env):
+            return convert_node(args.get("accept"), env=env)
+        else:
+            return convert_node(args.get("reject"),env=env)
     else:
         # first we resolve child nodes and arguments in an arbitrary but deterministic order
         args = {name: convert_node(expr, env=env) for (name, expr) in sorted(args.items())}

--- a/openeo_driver/datacube.py
+++ b/openeo_driver/datacube.py
@@ -210,6 +210,7 @@ class DriverVectorCube:
                 resp.raw.decode_content = True
                 location = io.BytesIO(resp.raw.read())
             geoDataframe = gpd.read_parquet(location)
+            log.info(f"Read geoparquet from {location} crs {geoDataframe.crs} length {len(geoDataframe)}")
 
             if("WGS 84 (CRS84)" in str(geoDataframe.crs)):
                 #workaround for not being able to decode ogc:crs84

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -764,11 +764,14 @@ def register_views_batch_jobs(
         process = {"process_graph": _extract_process_graph(post_data)}
         # TODO: this "job_options" is not part of official API. See https://github.com/Open-EO/openeo-api/issues/276
         job_options = post_data.get("job_options")
+        metadata_keywords = ["title", "description", "plan", "budget"]
+        if("job_options" not in post_data):
+            job_options = {k:v for (k,v) in post_data.items() if k not in metadata_keywords + ["process"]}
         job_info = backend_implementation.batch_jobs.create_job(
             user_id=user.user_id,
             process=process,
             api_version=g.api_version,
-            metadata={k: post_data[k] for k in ["title", "description", "plan", "budget"] if k in post_data},
+            metadata={k: post_data[k] for k in metadata_keywords if k in post_data},
             job_options=job_options,
         )
         job_id = job_info.id

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -766,7 +766,9 @@ def register_views_batch_jobs(
         job_options = post_data.get("job_options")
         metadata_keywords = ["title", "description", "plan", "budget"]
         if("job_options" not in post_data):
-            job_options = {k:v for (k,v) in post_data.items() if k not in metadata_keywords + ["process"]}
+            job_options = {k:v for (k,v) in post_data.items() if k not in metadata_keywords + ["process","process_graph"]}
+            if len(job_options)==0:
+                job_options = None
         job_info = backend_implementation.batch_jobs.create_job(
             user_id=user.user_id,
             process=process,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -989,6 +989,20 @@ class TestBatchJobs:
         job_info = dummy_backend.DummyBatchJobs._job_registry[TEST_USER, 'job-256']
         assert job_info.job_options == {"driver-memory": "3g", "executor-memory": "5g"}
 
+    def test_create_job_100_with_options_inline(self, api100):
+        with self._fresh_job_registry(next_job_id="job-256"):
+            resp = api100.post('/jobs', headers=self.AUTH_HEADER, json={
+                'process': {
+                    'process_graph': {"foo": {"process_id": "foo", "arguments": {}}},
+                    'summary': 'my foo job',
+                },
+                "driver-memory": "3g", "executor-memory": "5g"
+            }).assert_status_code(201)
+        assert resp.headers['Location'] == 'http://oeo.net/openeo/1.0.0/jobs/job-256'
+        assert resp.headers['OpenEO-Identifier'] == 'job-256'
+        job_info = dummy_backend.DummyBatchJobs._job_registry[TEST_USER, 'job-256']
+        assert job_info.job_options == {"driver-memory": "3g", "executor-memory": "5g"}
+
     def test_start_job(self, api):
         with self._fresh_job_registry(next_job_id="job-267") as registry:
             api.post('/jobs', headers=self.AUTH_HEADER, json=api.get_process_graph_dict(

--- a/tests/test_views_execute.py
+++ b/tests/test_views_execute.py
@@ -3034,11 +3034,12 @@ def test_if_merge_cubes(api100):
                 "bands": ["B04"],
             }},
         "eq1": {"process_id": "eq", "arguments": {"x": 4, "y": 3}},
+        "errornode":{"process_id":"doesntExist"},
         "if1": {
             "process_id": "if",
             "arguments": {
                 "value": {"from_node": "eq1"},
-                "accept": {"from_node": "loadcollection1"}, "reject": {"from_node": "loadcollection1"},
+                "accept": {"from_node": "errornode"}, "reject": {"from_node": "loadcollection1"},
             }},
         "mergecubes1": {
             "process_id": "merge_cubes",


### PR DESCRIPTION
Pull request to support job options that are specified at top level rather than in an explicit 'job_options' object. 
See: https://github.com/Open-EO/openeo-api/issues/276