### PR TITLE
Fix: ApiTest.result should support VectorCube

### DIFF
--- a/openeo_driver/testing.py
+++ b/openeo_driver/testing.py
@@ -20,6 +20,7 @@ from werkzeug.datastructures import Headers
 
 import openeo
 import openeo.processes
+import openeo.rest.vectorcube
 from openeo.capabilities import ComparableVersion
 from openeo_driver.users.auth import HttpAuthHandler
 from openeo_driver.util.geometry import (
@@ -261,7 +262,13 @@ class ApiTester:
 
     def result(
         self,
-        process_graph: Union[dict, str, openeo.DataCube, openeo.processes.ProcessBuilderBase],
+        process_graph: Union[
+            dict,
+            str,
+            openeo.DataCube,
+            openeo.processes.ProcessBuilderBase,
+            openeo.rest.vectorcube.VectorCube,
+        ],
         path="/result",
         preprocess: Callable = None,
     ) -> ApiResponse:
@@ -273,7 +280,12 @@ class ApiTester:
             # Assume it is a file name
             process_graph = self.load_json(process_graph, preprocess=preprocess)
         elif isinstance(
-            process_graph, (openeo.DataCube, openeo.processes.ProcessBuilderBase)
+            process_graph,
+            (
+                openeo.DataCube,
+                openeo.processes.ProcessBuilderBase,
+                openeo.rest.vectorcube.VectorCube,
+            ),
         ):
             process_graph = process_graph.flat_graph()
         data = self.get_process_graph_dict(process_graph)


### PR DESCRIPTION
Fixes issue: https://github.com/Open-EO/openeo-python-driver/issues/179