### PR TITLE
Shed importlib resources legacy

### DIFF
--- a/openeo_driver/config/load.py
+++ b/openeo_driver/config/load.py
@@ -41,15 +41,11 @@ def load_from_py_file(
     try:
         config = globals[variable]
     except KeyError:
-        raise ConfigException(
-            f"No variable {variable!r} found in config file {path!r}"
-        ) from None
+        raise ConfigException(f"No variable {variable!r} found in config file {path!r}") from None
 
     if expected_class:
         if not isinstance(config, expected_class):
-            raise ConfigException(
-                f"Expected {expected_class.__name__} but got {type(config).__name__}"
-            )
+            raise ConfigException(f"Expected {expected_class.__name__} but got {type(config).__name__}")
     return config
 
 

--- a/openeo_driver/config/load.py
+++ b/openeo_driver/config/load.py
@@ -77,7 +77,7 @@ class ConfigGetter:
         """
         Default config file (as a context manager to allow it to be an ephemeral resource).
         """
-        return importlib_resources.path("openeo_driver.config", "default.py")
+        return importlib_resources.as_file(importlib_resources.files("openeo_driver.config") / "default.py")
 
     def _load(self, reason: Optional[str] = None) -> OpenEoBackendConfig:
         """Load the config from config file."""

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "python-dateutil",
         "python-json-logger>=2.0.0",
         "deprecated>=1.2.12",
-        "importlib_resources<6.0.0; python_version<'3.10'",  # '<6.0.0' becaue of https://github.com/Open-EO/openeo-python-driver/issues/206
+        "importlib_resources; python_version<'3.10'",
         "attrs",
     ],
     extras_require={


### PR DESCRIPTION
- ⚫ Fade to black.
- Switch to non-legacy API for loading resources. Fixes #206.
