### PR TITLE
Mask twice overlap

### DIFF
--- a/tests/test_ProcessGraphDeserializer.py
+++ b/tests/test_ProcessGraphDeserializer.py
@@ -5,6 +5,8 @@ from openeo.rest.datacube import DataCube, PGNode
 from openeo_driver.ProcessGraphDeserializer import (
     _period_to_intervals,
     SimpleProcessing,
+    flatten_children_node_types,
+    flatten_children_node_names,
 )
 from openeo_driver.errors import ProcessParameterRequiredException
 
@@ -223,3 +225,30 @@ class TestSimpleProcessing:
         pg = cube.flat_graph()
         processing = SimpleProcessing()
         assert processing.evaluate(pg) == 11
+
+    def test_get_all_dependency_nodes(self):
+        process_graph = {
+            "from_node": "filter1",
+            "node": {
+                "arguments": {
+                    "bands": [
+                        "B02"
+                    ],
+                    "data": {
+                        "from_node": "load_collection1",
+                        "node": {
+                            "arguments": {
+                                "id": "S2_FOOBAR"
+                            },
+                            "process_id": "load_collection"
+                        }
+                    }
+                },
+                "process_id": "filter_bands"
+            }
+        }
+        children_node_types = flatten_children_node_types(process_graph)
+        children_node_names = flatten_children_node_names(process_graph)
+
+        assert len(children_node_types) == 2
+        assert len(children_node_names) == 2

--- a/tests/test_views_execute.py
+++ b/tests/test_views_execute.py
@@ -962,7 +962,7 @@ def test_data_mask_use_data_twice(api100):
     dummy = dummy_backend.get_collection("S2_FOOBAR")
     # Not handling overlaps between mask and data nodes.
     # A load_collection under the data node could be used twice and would not be pre-masked correctly.
-    assert dummy.mask.call_count == 0
+    assert dummy.mask.call_count == 1
 
 def test_data_mask_unoptimized(api100):
     pg = {


### PR DESCRIPTION
Overlap between data and mask node, do not pre-apply mask on load_collections. The load collections might be cached, and then it could be incorrect to pre-apply mask, or assume it was already pre-applied.

Example graph that illustrates the problem:
![image](https://github.com/Open-EO/openeo-python-driver/assets/2298426/9ae30e43-c456-4e73-96c3-632bcac25794)
