### PR TITLE
Issue #215 Fix: report correct job status in _list_job_results when p…

### DIFF
--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -956,9 +956,11 @@ def register_views_batch_jobs(
                 elif job_info.status == JOB_STATUS.CANCELED:
                     openeo_status = "canceled"
                 elif job_info.status == JOB_STATUS.QUEUED:
-                    openeo_status = "queued"
+                    openeo_status = "running"
                 elif job_info.status == JOB_STATUS.CREATED:
-                    openeo_status = "created"
+                    openeo_status = "running"
+                else:
+                    raise AssertionError(f"unexpected job status: {job_info.status!r}")
 
                 result = {
                     "openeo:status": openeo_status,

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -949,8 +949,19 @@ def register_views_batch_jobs(
             if not partial:
                 raise JobNotFinishedException()
             else:
+                if job_info.status == JOB_STATUS.RUNNING:
+                    openeo_status = "running"
+                elif job_info.status == JOB_STATUS.ERROR:
+                    openeo_status = "error"
+                elif job_info.status == JOB_STATUS.CANCELED:
+                    openeo_status = "canceled"
+                elif job_info.status == JOB_STATUS.QUEUED:
+                    openeo_status = "queued"
+                elif job_info.status == JOB_STATUS.CREATED:
+                    openeo_status = "created"
+
                 result = {
-                    "openeo:status": "running",
+                    "openeo:status": openeo_status,
                     "type": "Collection",
                     "stac_version": "1.0.0",
                     "id": job_id,
@@ -1083,6 +1094,7 @@ def register_views_batch_jobs(
                         "providers": providers or None,
                         "links": links,
                         "assets": assets,
+                        "openeo:status": "finished",
                     }
                 )
 
@@ -1107,7 +1119,8 @@ def register_views_batch_jobs(
                     "id": job_info.id,
                     "properties": _properties_from_job_info(job_info),
                     "assets": assets,
-                    "links": links
+                    "links": links,
+                    "openeo:status": "finished",
                 }
                 if providers:
                     result["providers"] = providers


### PR DESCRIPTION
## Issue #215 Fix: report correct job status in _list_job_results when partial=true

This PR corrects the reported job status for some cases in the context of https://github.com/Open-EO/openeo-geopyspark-driver/issues/489, as noted by  @bossie, here: https://github.com/Open-EO/openeo-python-driver/issues/215#issuecomment-1682261335 .

- if partial and job error/canceled -> openeo:status running (expected: error/canceled)
- if partial and job finished -> no openeo:status (expected: finished)
- if not partial and job error/canceled -> JobNotFinishedException; after some contemplating I believe this is still OK as the back-end is not required to return intermediate results.

### Solution in brief:

Basically we should report the actual job status when partial is true, and also include openeo:status when the job is finished. 
- When partial is false and the jobs is not finished, do the same as before: raise JobNotFinishedException.