### PR TITLE
Stac alternate

### DIFF
--- a/openeo_driver/testing.py
+++ b/openeo_driver/testing.py
@@ -19,6 +19,7 @@ import attrs
 import openeo
 import openeo.processes
 import pytest
+import requests
 import shapely.geometry.base
 import shapely.wkt
 from flask import Response
@@ -494,7 +495,6 @@ class UrllibMocker:
     def mocked_requests_get(self, req, **kwargs):
         urllib_resp = self._http_open(urllib.request.Request(req.url))
 
-        import requests
         resp = requests.Response()
         resp.status_code = urllib_resp.code
         resp.raw = io.BytesIO(urllib_resp.data)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -180,7 +180,6 @@ class TestUrllibMocker:
     def test_requests(self, urllib_mock: UrllibMocker):
         href = "http://a.test/foo"
         urllib_mock.get(href, data="hello world")
-        import requests
 
         with requests.get(href) as resp:
             resp.raise_for_status()
@@ -189,9 +188,7 @@ class TestUrllibMocker:
     def test_stac_client(self, urllib_mock: UrllibMocker):
         href = "http://a.test/foo"
         urllib_mock.get(href, data="hello world")
-        headers = {}
-        params = {}
-        request = requests.models.Request(method="GET", url=href, headers=headers, params=params)
+        request = requests.models.Request(method="GET", url=href, headers={}, params={})
         request = request.prepare()
         resp = requests.session().send(request)
         assert resp.content == b"hello world"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -174,8 +174,27 @@ class TestUrllibMocker:
         assert r.read() == b"hello world"
 
     def test_get_not_found(self, urllib_mock: UrllibMocker):
-        with pytest.raises(urllib.error.HTTPError, match="404: Not Found"):
+        with pytest.raises(urllib.error.HTTPError, match="404: Not found not in mock: http://a.test/bar"):
             urllib.request.urlopen("http://a.test/bar")
+
+    def test_requests(self, urllib_mock: UrllibMocker):
+        href = "http://a.test/foo"
+        urllib_mock.get(href, data="hello world")
+        import requests
+
+        with requests.get(href) as resp:
+            resp.raise_for_status()
+            assert resp.text == "hello world"
+
+    def test_stac_client(self, urllib_mock: UrllibMocker):
+        href = "http://a.test/foo"
+        urllib_mock.get(href, data="hello world")
+        headers = {}
+        params = {}
+        request = requests.models.Request(method="GET", url=href, headers=headers, params=params)
+        request = request.prepare()
+        resp = requests.session().send(request)
+        assert resp.content == b"hello world"
 
     def test_context_manager_get(self, urllib_mock: UrllibMocker):
         urllib_mock.get("http://a.test/foo", data="hello world")


### PR DESCRIPTION
Proxy `requests.models.Request` to use the existing `urllib` mocking