### PR TITLE
Allow for files in subdirectories to keep their relative paths in export_workspace.

### DIFF
--- a/openeo_driver/utils.py
+++ b/openeo_driver/utils.py
@@ -153,6 +153,11 @@ def read_json(filename: Union[str, Path]) -> Union[dict, list]:
         return json.load(f)
 
 
+def remove_slash_prefix(path: Union[str, Path]):
+    path = str(path)
+    return path[1:] if path.startswith("/") else path
+
+
 def smart_bool(value: Any) -> bool:
     """
     Convert given value to a boolean value, like `bool()` builtin,

--- a/openeo_driver/workspace.py
+++ b/openeo_driver/workspace.py
@@ -3,18 +3,20 @@ import logging
 import os.path
 import shutil
 from pathlib import Path
+from typing import Union
 
+from openeo_driver.utils import remove_slash_prefix
 
 _log = logging.getLogger(__name__)
 
 
 class Workspace(abc.ABC):
     @abc.abstractmethod
-    def import_file(self, file: Path, merge: str, remove_original: bool = False) -> str:
+    def import_file(self, common_path: str, file: Path, merge: str, remove_original: bool = False) -> str:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def import_object(self, s3_uri: str, merge: str, remove_original: bool = False):
+    def import_object(self, common_path: str, s3_uri: str, merge: str, remove_original: bool = False) -> str:
         raise NotImplementedError
 
 
@@ -23,10 +25,11 @@ class DiskWorkspace(Workspace):
     def __init__(self, root_directory: Path):
         self.root_directory = root_directory
 
-    def import_file(self, file: Path, merge: str, remove_original: bool = False) -> str:
+    def import_file(self, common_path: Union[str, Path], file: Path, merge: str, remove_original: bool = False) -> str:
         merge = os.path.normpath(merge)
-        subdirectory = merge[1:] if merge.startswith("/") else merge
-        target_directory = self.root_directory / subdirectory
+        subdirectory = remove_slash_prefix(merge)
+        file_relative = file.relative_to(common_path)
+        target_directory = self.root_directory / subdirectory / file_relative.parent
         target_directory.relative_to(self.root_directory)  # assert target_directory is in root_directory
 
         target_directory.mkdir(parents=True, exist_ok=True)
@@ -37,5 +40,5 @@ class DiskWorkspace(Workspace):
         _log.debug(f"{'moved' if remove_original else 'copied'} {file.absolute()} to {target_directory}")
         return f"file:{target_directory / file.name}"
 
-    def import_object(self, s3_uri: str, merge: str, remove_original: bool = False):
+    def import_object(self, common_path: str, s3_uri: str, merge: str, remove_original: bool = False):
         raise NotImplementedError(f"importing objects is not supported yet")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -20,7 +20,7 @@ def test_disk_workspace(tmp_path, merge):
     target_directory = tmp_path / subdirectory
 
     workspace = DiskWorkspace(root_directory=tmp_path)
-    workspace.import_file(file=source_file, merge=merge)
+    workspace.import_file(common_path=source_directory, file=source_file, merge=merge)
 
     assert (target_directory / source_file.name).exists()
     assert source_file.exists()
@@ -37,7 +37,7 @@ def test_disk_workspace_remove_original(tmp_path, remove_original):
     target_directory = tmp_path / merge
 
     workspace = DiskWorkspace(root_directory=tmp_path)
-    workspace.import_file(source_file, merge=merge, remove_original=remove_original)
+    workspace.import_file(common_path=source_directory, file=source_file, merge=merge, remove_original=remove_original)
 
     assert (target_directory / source_file.name).exists()
     assert source_file.exists() != remove_original


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/877