### PR TITLE
auto-convert incoming geojson to vectorcube

### DIFF
--- a/openeo_driver/ProcessGraphDeserializer.py
+++ b/openeo_driver/ProcessGraphDeserializer.py
@@ -1392,10 +1392,10 @@ def filter_spatial(args: Dict, env: EvalEnv) -> DriverDataCube:
         )
 
     if isinstance(geometries, dict):
-        if "type" in geometries and geometries["type"] == "FeatureCollection":
-            geometries = DriverVectorCube.from_geojson(geometries)
+        if "type" in geometries and geometries["type"] != "GeometryCollection":
+            geometries = env.backend_implementation.vector_cube_cls.from_geojson(geometries)
         else:
-                        # TODO #71 #114 #268 EP-3981 avoid GeometryCollection and standardize on vector cubes
+            # TODO #71 #114 #268 EP-3981 phase out special handling of GeometryCollection
             geometries = geojson_to_geometry(geometries)
             if isinstance(geometries, GeometryCollection):
                 polygons = [
@@ -1403,6 +1403,7 @@ def filter_spatial(args: Dict, env: EvalEnv) -> DriverDataCube:
                     for geom in geometries.geoms
                 ]
                 geometries = MultiPolygon(polygons)
+
 
     elif isinstance(geometries, DelayedVector):
         geometries = DriverVectorCube.from_fiona([geometries.path]).to_multipolygon()

--- a/openeo_driver/datacube.py
+++ b/openeo_driver/datacube.py
@@ -456,8 +456,7 @@ class DriverVectorCube:
             crs = CRS(crs["properties"]["name"])
         if crs == cls.CRS_LAT_LNG:
             validate_geojson_coordinates(geojson)
-        # TODO support more geojson types?
-        if geojson["type"] in {"Polygon", "MultiPolygon", "Point", "MultiPoint"}:
+        if geojson["type"] in {"Polygon", "MultiPolygon", "Point", "MultiPoint", "MultiLineString", "LineString"}:
             features = [{"type": "Feature", "geometry": geojson, "properties": {}}]
         elif geojson["type"] in {"Feature"}:
             features = [geojson]

--- a/openeo_driver/dry_run.py
+++ b/openeo_driver/dry_run.py
@@ -593,11 +593,6 @@ class DryRunDataCube(DriverDataCube):
         elif isinstance(geometries, DelayedVector):
             bbox = geometries.bounds
         elif isinstance(geometries, shapely.geometry.base.BaseGeometry):
-            _log.warning(
-                "_normalize_geometry: TODO are we still reaching this code?",
-                # TODO yes we are, apparently due to #288
-                stack_info=True,
-            )
             # TODO: buffer distance of 10m assumes certain resolution (e.g. sentinel2 pixels)
             # TODO: use proper distance for collection resolution instead of using a default distance?
             # TODO: or eliminate need for buffering in the first place? https://github.com/Open-EO/openeo-python-driver/issues/148

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -6,6 +6,7 @@ from unittest import mock
 import openeo.processes
 from openeo.internal.graph_building import PGNode
 from openeo.rest.datacube import DataCube
+from openeo_driver.dummy.dummy_backend import DummyVectorCube
 
 from openeo_driver.errors import OpenEOApiException
 from openeo_driver.ProcessGraphDeserializer import evaluate, ENV_DRY_RUN_TRACER, _extract_load_parameters, \
@@ -872,12 +873,12 @@ def test_multiple_filter_spatial(dry_run_env, dry_run_tracer):
     geometries = dry_run_tracer.get_last_geometry(operation="filter_spatial")
     assert constraints == {
         "spatial_extent": {'crs': 'EPSG:4326','east': 8.0,'north': 5.0,'south': 0.0,'west': 0.0},
-        "filter_spatial": {"geometries": shapely.geometry.shape(polygon1)},
+        "filter_spatial": {"geometries": DummyVectorCube.from_geometry(shapely.geometry.shape(polygon1))},
         "resample": {"method": "near", "resolution": [0.25, 0.25], "target_crs": 4326},
         "weak_spatial_extent": {"west": 0.0, "south": 0.0, "east": 8.0, "north": 5.0, "crs": "EPSG:4326"},
     }
 
-    assert geometries == shapely.geometry.shape(polygon2)
+    assert geometries == DummyVectorCube.from_geometry(shapely.geometry.shape(polygon2))
 
 
 @pytest.mark.parametrize(
@@ -969,12 +970,12 @@ def test_resample_filter_spatial(dry_run_env, dry_run_tracer):
     geometries, = dry_run_tracer.get_geometries(operation="filter_spatial")
     assert constraints == {
         "spatial_extent": {'crs': 'EPSG:4326','east': 8.0,'north': 5.0,'south': 0.0,'west': 0.0},
-        "filter_spatial": {"geometries": shapely.geometry.shape(polygon)},
+        "filter_spatial": {"geometries": DummyVectorCube.from_geometry(shapely.geometry.shape(polygon))},
         "resample": {"method": "near", "resolution": [0.25, 0.25], "target_crs": 4326},
         "weak_spatial_extent": {"west": 0.0, "south": 0.0, "east": 8.0, "north": 5.0, "crs": "EPSG:4326"},
     }
-    assert isinstance(geometries, shapely.geometry.Polygon)
-    assert shapely.geometry.mapping(geometries) == {
+    assert isinstance(geometries,DummyVectorCube)
+    assert shapely.geometry.mapping(geometries.to_multipolygon()) == {
         "type": "Polygon",
         "coordinates": (((0.0, 0.0), (3.0, 5.0), (8.0, 2.0), (0.0, 0.0)),)
     }
@@ -1014,11 +1015,11 @@ def test_auto_align(dry_run_env, dry_run_tracer):
     geometries, = dry_run_tracer.get_geometries(operation="filter_spatial")
     assert constraints == {
         "spatial_extent": {'crs': 'EPSG:4326','east': 8.0,'north': 5.0,'south': 0.1,'west': 0.1},
-        "filter_spatial": {"geometries": shapely.geometry.shape(polygon)},
+        "filter_spatial": {"geometries": DummyVectorCube.from_geometry(shapely.geometry.shape(polygon))},
         "weak_spatial_extent": {"west": 0.1, "south": 0.1, "east": 8.0, "north": 5.0, "crs": "EPSG:4326"},
     }
-    assert isinstance(geometries, shapely.geometry.Polygon)
-    assert shapely.geometry.mapping(geometries) == {
+    assert isinstance(geometries, DummyVectorCube)
+    assert shapely.geometry.mapping(geometries.to_multipolygon()) == {
         "type": "Polygon",
         "coordinates": (((0.1, 0.1), (3.0, 5.0), (8.0, 2.0), (0.1, 0.1)),)
     }
@@ -1046,7 +1047,7 @@ def test_global_bounds_from_weak_spatial_extent(dry_run_env, dry_run_tracer):
     assert constraints == {
         "spatial_extent": {"west": 1, "south": 1, "east": 3, "north": 3, "crs": "EPSG:4326"},
         "weak_spatial_extent": {"crs": "EPSG:4326", "east": 8.0, "north": 5.0, "south": 0.1, "west": 0.1},
-        "filter_spatial": {"geometries": shapely.geometry.shape(polygon)},
+        "filter_spatial": {"geometries": DummyVectorCube.from_geometry(shapely.geometry.shape(polygon))},
     }
     dry_run_env = dry_run_env.push({ENV_SOURCE_CONSTRAINTS: source_constraints})
     load_params = _extract_load_parameters(


### PR DESCRIPTION
For consistent and correct handling of geometry in our backend, we need vector cubes.
This code path was still emitting shapely geometry objects, for no clear/good reason, causing unexpected behaviour:
https://github.com/VITO-RS-Vegetation/lcfm-production/issues/88

The error logs show clearly that geometry with different CRS's was incorrectly combined when vector cubes are not used.

Next to that, annoying messages were printed in the logs:

```
geojson_to_geometry usage is deprecated and should be replaced by proper vector cube usage
_normalize_geometry: TODO are we still reaching this code?
```

This pr suggests to get rid of all that via a simple translation to vector cube, which is a code path with much better support and normally also test coverage.

@soxofaan  @JeroenVerstraelen  I can add a unit test, but would first like to learn if there were reasons to not do this?