### PR TITLE
workspace URIs only apply to newly exported assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and start a new "In Progress" section above it.
 
 - `load_collection`: more consistent cube extent handling when a buffer is applied. ([#334](https://github.com/Open-EO/openeo-python-driver/issues/334))
 - `load_collection`: collapse multiple `load_collection` calls into a single one in cases with buffers. ([#336](https://github.com/Open-EO/openeo-python-driver/issues/336))
+- `export_workspace`: fix `KeyError: 'alternate'` upon merging into existing STAC collection ([Open-EO/openeo-geopyspark-driver#677)](https://github.com/Open-EO/openeo-geopyspark-driver/issues/677))
 
 ## 0.121.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@ and start a new "In Progress" section above it.
 
 - `load_collection`: more consistent cube extent handling when a buffer is applied. ([#334](https://github.com/Open-EO/openeo-python-driver/issues/334))
 - `load_collection`: collapse multiple `load_collection` calls into a single one in cases with buffers. ([#336](https://github.com/Open-EO/openeo-python-driver/issues/336))
-- `export_workspace`: fix `KeyError: 'alternate'` upon merging into existing STAC collection ([Open-EO/openeo-geopyspark-driver#677)](https://github.com/Open-EO/openeo-geopyspark-driver/issues/677))
+- `export_workspace`: fix `KeyError: 'alternate'` upon merging into existing STAC collection ([Open-EO/openeo-geopyspark-driver#677](https://github.com/Open-EO/openeo-geopyspark-driver/issues/677))
 
 ## 0.121.0
 
-- `export_workspace`: experimental support for merging STAC Collections ([Open-EO/openeo-geopyspark-driver#677)](https://github.com/Open-EO/openeo-geopyspark-driver/issues/677))
+- `export_workspace`: experimental support for merging STAC Collections ([Open-EO/openeo-geopyspark-driver#677](https://github.com/Open-EO/openeo-geopyspark-driver/issues/677))
 
 ## 0.120.0
 

--- a/openeo_driver/workspace.py
+++ b/openeo_driver/workspace.py
@@ -110,8 +110,6 @@ class DiskWorkspace(Workspace):
                         file_operation(
                             asset.extra_fields["_original_absolute_href"], str(Path(new_item.get_self_href()).parent)
                         )
-
-                merged_collection = new_collection
             else:
                 merged_collection = _merge_collection_metadata(existing_collection, new_collection)
                 new_collection = new_collection.map_assets(replace_asset_href)
@@ -129,12 +127,12 @@ class DiskWorkspace(Workspace):
                             asset.extra_fields["_original_absolute_href"], Path(new_item.get_self_href()).parent
                         )
 
-            for item in merged_collection.get_items():
+            for item in new_collection.get_items():
                 for asset in item.assets.values():
                     workspace_uri = f"file:{Path(item.get_self_href()).parent / Path(asset.href).name}"
                     asset.extra_fields["alternate"] = {"file": workspace_uri}
 
-            return merged_collection
+            return new_collection
         else:
             raise NotImplementedError(stac_resource)
 
@@ -148,6 +146,7 @@ def _merge_collection_metadata(existing_collection: Collection, new_collection: 
         existing_collection.extent.temporal, new_collection.extent.temporal
     )
 
+    # TODO: retains existing collection ID and description; is this right?
     # TODO: merge additional metadata?
 
     return existing_collection

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -106,16 +106,15 @@ def test_merge_from_disk_into_existing(tmp_path):
 
     workspace = DiskWorkspace(root_directory=tmp_path)
     workspace.merge(stac_resource=existing_collection, target=target)
-    merged_collection = workspace.merge(stac_resource=new_collection, target=target)
+    imported_collection = workspace.merge(stac_resource=new_collection, target=target)
 
-    assert isinstance(merged_collection, Collection)
+    assert isinstance(imported_collection, Collection)
     asset_workspace_uris = {
         asset_key: asset.extra_fields["alternate"]["file"]
-        for item in merged_collection.get_items()
+        for item in imported_collection.get_items()
         for asset_key, asset in item.get_assets().items()
     }
     assert asset_workspace_uris == {
-        "asset1.tif": f"file:{workspace.root_directory / 'path' / 'to' / 'collection.json_items' / 'asset1.tif'}",
         "asset2.tif": f"file:{workspace.root_directory / 'path' / 'to' / 'collection.json_items' / 'asset2.tif'}",
     }
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from pystac import Asset, Collection, Extent, Item, SpatialExtent, TemporalExtent, CatalogType
 import pytest
-from pystac.layout import CustomLayoutStrategy
 
 from openeo_driver.workspace import DiskWorkspace
 
@@ -58,12 +57,12 @@ def test_merge_from_disk_new(tmp_path):
     target = Path("path") / "to" / "collection.json"
 
     workspace = DiskWorkspace(root_directory=tmp_path)
-    merged_collection = workspace.merge(stac_resource=new_collection, target=target)
+    imported_collection = workspace.merge(stac_resource=new_collection, target=target)
 
-    assert isinstance(merged_collection, Collection)
+    assert isinstance(imported_collection, Collection)
     asset_workspace_uris = {
         asset_key: asset.extra_fields["alternate"]["file"]
-        for item in merged_collection.get_items()
+        for item in imported_collection.get_items()
         for asset_key, asset in item.get_assets().items()
     }
     assert asset_workspace_uris == {


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/677

```
Traceback (most recent call last):
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/deploy/batch_job.py", line 763, in start_main
    main(sys.argv)
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/deploy/batch_job.py", line 246, in main
    run_driver()
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/deploy/batch_job.py", line 207, in run_driver
    run_job(
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/utils.py", line 57, in memory_logging_wrapper
    return function(*args, **kwargs)
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/deploy/batch_job.py", line 489, in run_job
    stac_file_paths += _export_to_workspaces(
  File "/opt/openeo/lib/python3.8/site-packages/openeogeotrellis/deploy/batch_job.py", line 568, in _export_to_workspaces
    (workspace_uri,) = asset.extra_fields["alternate"].values()
KeyError: 'alternate'
```