### PR TITLE
Suffix to remove

### DIFF
--- a/openeo_driver/datacube.py
+++ b/openeo_driver/datacube.py
@@ -576,18 +576,18 @@ class DriverVectorCube:
             options = {}
         # TODO: We should treat the directory parameter as an actual directory. (Open-EO/openeo-geopyspark-driver#888)
         filename = str(directory)
-        directory = Path(filename).parent
+        directory_parent = Path(filename).parent
 
         format_info = IOFORMATS.get(format)
         # TODO: check if format can be used for vector data?
-        path = directory / f"vectorcube.{format_info.extension}"
+        path = directory_parent / f"vectorcube.{format_info.extension}"
 
         if format_info.format == "JSON":
             # TODO: eliminate this legacy format?
             log.warning(
                 f"Exporting vector cube {self} to legacy, non-standard JSON format"
             )
-            return self.to_legacy_save_result().write_assets(directory / "suffix_to_remove")
+            return self.to_legacy_save_result().write_assets(directory)
 
         gdf = self._as_geopandas_df(flatten_prefix=options.get("flatten_prefix"))
         if format_info.format == "Parquet":
@@ -605,7 +605,7 @@ class DriverVectorCube:
             }}
         else:
             # Multi-file format
-            components = list(directory.glob("vectorcube.*"))
+            components = list(directory_parent.glob("vectorcube.*"))
             if options.get("zip_multi_file"):
                 # TODO: automatically zip shapefile components?
                 zip_path = path.with_suffix(f".{format_info.extension}.zip")

--- a/openeo_driver/datacube.py
+++ b/openeo_driver/datacube.py
@@ -587,7 +587,7 @@ class DriverVectorCube:
             log.warning(
                 f"Exporting vector cube {self} to legacy, non-standard JSON format"
             )
-            return self.to_legacy_save_result().write_assets(directory)
+            return self.to_legacy_save_result().write_assets(directory / "suffix_to_remove")
 
         gdf = self._as_geopandas_df(flatten_prefix=options.get("flatten_prefix"))
         if format_info.format == "Parquet":

--- a/openeo_driver/save_result.py
+++ b/openeo_driver/save_result.py
@@ -205,6 +205,7 @@ class VectorCubeResult(SaveResult):
             asset = assets.popitem()[1]
             path = Path(asset["href"])
             mimetype = asset.get("type")
+            assert path.relative_to(tmp_dir)
             return send_from_directory(path.parent, path.name, mimetype=mimetype)
 
 


### PR DESCRIPTION
https://github.com/Open-EO/openeo-python-driver/issues/342

There are 2 `write_assets` functions. Both takes the suffix from the paths. One can call the other, but this happens after the suffix is removed from the path. Here, I add a new suffix so that the nested `write_assets` works fine