### PR TITLE
feature: asset_urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and start a new "In Progress" section above it.
 
 ## In progress: 0.134.0
 
+- Introduce `asset_url` option to allow backend implementations to have custom code for retrieving assets. Default
+  behavior remains unchanged.
 
 ## 0.133.0
 

--- a/openeo_driver/asset_urls.py
+++ b/openeo_driver/asset_urls.py
@@ -1,5 +1,7 @@
 import logging
 from openeo_driver.users import user_id_b64_encode
+import openeo_driver.config
+
 import flask
 _log = logging.getLogger(__name__)
 
@@ -19,9 +21,7 @@ class AssetUrl:
         If an url_signer is defined these urls will be signed.
 
         """
-        from openeo_driver import backend  # otherwise circular import
-
-        signer = backend.get_backend_config().url_signer
+        signer = openeo_driver.config.get_backend_config().url_signer
         if signer:
             expires = signer.get_expires()
             secure_key = signer.sign_job_asset(

--- a/openeo_driver/asset_urls.py
+++ b/openeo_driver/asset_urls.py
@@ -1,0 +1,51 @@
+import logging
+from typing import Optional
+
+from openeo_driver.users import user_id_b64_encode
+from openeo_driver.urlsigning import UrlSigner
+from functools import lru_cache
+import flask
+_log = logging.getLogger(__name__)
+
+
+class AssetUrl:
+    """
+    This class helps to convert internal storage locations to asset urls
+
+
+    If assets are not stored on local storage it is possible to come up with other implementations that extend this
+    class and go straight to the external storage. If the driver always has access to the artifacts then it is
+     recommended fallback to the default implementation by calling the method from its base class.
+    """
+    def get(self, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
+        """
+        The default implementation will create urls that go to the driver application.
+        If an url_signer is defined these urls will be signed.
+
+        """
+        signer = self._get_signer()
+        if signer:
+            expires = signer.get_expires()
+            secure_key = signer.sign_job_asset(
+                job_id=job_id, user_id=user_id, filename=asset_name, expires=expires
+            )
+            user_base64 = user_id_b64_encode(user_id)
+            return flask.url_for(
+                '.download_job_result_signed',
+                job_id=job_id, user_base64=user_base64, filename=asset_name, expires=expires, secure_key=secure_key,
+                _external=True
+            )
+        else:
+            return flask.url_for('.download_job_result', job_id=job_id, filename=asset_name, _external=True)
+
+    @lru_cache()
+    def _get_signer(self) -> Optional[UrlSigner]:
+        """
+        A helper to get a signer from config.
+
+        It uses local imports because config does contain a asset_url object so if we have an import in this package
+        it results in a circular import.
+        """
+        from openeo_driver.backend import get_backend_config
+
+        return get_backend_config().url_signer

--- a/openeo_driver/asset_urls.py
+++ b/openeo_driver/asset_urls.py
@@ -38,7 +38,6 @@ class AssetUrl:
         else:
             return flask.url_for('.download_job_result', job_id=job_id, filename=asset_name, _external=True)
 
-    @lru_cache()
     def _get_signer(self) -> Optional[UrlSigner]:
         """
         A helper to get a signer from config.

--- a/openeo_driver/asset_urls.py
+++ b/openeo_driver/asset_urls.py
@@ -19,7 +19,7 @@ class AssetUrl:
         If an url_signer is defined these urls will be signed.
 
         """
-        from openeo_driver import backend  # otherwise cicurlar import
+        from openeo_driver import backend  # otherwise circular import
 
         signer = backend.get_backend_config().url_signer
         if signer:

--- a/openeo_driver/asset_urls.py
+++ b/openeo_driver/asset_urls.py
@@ -13,7 +13,7 @@ class AssetUrl:
     class and go straight to the external storage. If the driver always has access to the artifacts then it is
      recommended fallback to the default implementation by calling the method from its base class.
     """
-    def build_url(self, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
+    def build_url(self, *, asset_metadata: dict, asset_name: str, job_id: str, user_id: str) -> str:
         """
         The default implementation will create urls that go to the driver application.
         If an url_signer is defined these urls will be signed.

--- a/openeo_driver/config/config.py
+++ b/openeo_driver/config/config.py
@@ -14,6 +14,7 @@ from openeo_driver.server import build_backend_deploy_metadata
 from openeo_driver.urlsigning import UrlSigner
 from openeo_driver.users.oidc import OidcProvider
 from openeo_driver.workspace import Workspace
+from openeo_driver.asset_urls import AssetUrl
 
 __all__ = ["OpenEoBackendConfig", "openeo_backend_config_class", "ConfigException", "check_config_definition"]
 
@@ -67,6 +68,7 @@ class OpenEoBackendConfig(_ConfigBase):
     )
 
     url_signer: Optional[UrlSigner] = None
+    asset_url: AssetUrl = AssetUrl()
 
     """
     Collection exclusion list: mapping of API version to collections to exclude

--- a/openeo_driver/config/config.py
+++ b/openeo_driver/config/config.py
@@ -68,7 +68,7 @@ class OpenEoBackendConfig(_ConfigBase):
     )
 
     url_signer: Optional[UrlSigner] = None
-    asset_url: AssetUrl = AssetUrl()
+    asset_url: AssetUrl = attrs.Factory(AssetUrl)
 
     """
     Collection exclusion list: mapping of API version to collections to exclude

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1464,7 +1464,7 @@ def register_views_batch_jobs(
         for asset in assets.values():
             if not asset["href"].startswith("http"):
                 asset_file_name = pathlib.Path(asset["href"]).name
-                asset["href"] = backend_implementation.config.asset_url.get(asset, asset_file_name, job_id, user_id)
+                asset["href"] = backend_implementation.config.asset_url.get(asset_metadata=asset, asset_name=asset_file_name, job_id=job_id, user_id=user_id)
         stac_item = {
             "stac_version": ml_model_metadata.get("stac_version", "0.9.0"),
             "stac_extensions": ml_model_metadata.get("stac_extensions", []),

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1038,22 +1038,6 @@ def register_views_batch_jobs(
             _log.info(f"`POST /jobs/{job_id}/results`: not (re)starting job (status {job_info.status}")
         return make_response("", 202)
 
-    def _job_result_download_url(job_id, user_id, filename) -> str:
-        signer = get_backend_config().url_signer
-        if signer:
-            expires = signer.get_expires()
-            secure_key = signer.sign_job_asset(
-                job_id=job_id, user_id=user_id, filename=filename, expires=expires
-            )
-            user_base64 = user_id_b64_encode(user_id)
-            return url_for(
-                '.download_job_result_signed',
-                job_id=job_id, user_base64=user_base64, filename=filename, expires=expires, secure_key=secure_key,
-                _external=True
-            )
-        else:
-            return url_for('.download_job_result', job_id=job_id, filename=filename, _external=True)
-
     @api_endpoint
     @blueprint.route('/jobs/<job_id>/results', methods=['GET'])
     @auth_handler.requires_bearer_auth
@@ -1480,7 +1464,7 @@ def register_views_batch_jobs(
         for asset in assets.values():
             if not asset["href"].startswith("http"):
                 asset_file_name = pathlib.Path(asset["href"]).name
-                asset["href"] = _job_result_download_url(job_id, user_id, asset_file_name)
+                asset["href"] = backend_implementation.config.asset_url.get(asset, job_id, user_id, asset_file_name)
         stac_item = {
             "stac_version": ml_model_metadata.get("stac_version", "0.9.0"),
             "stac_extensions": ml_model_metadata.get("stac_extensions", []),
@@ -1502,7 +1486,7 @@ def register_views_batch_jobs(
             {
                 "title": asset_metadata.get("title", filename),
                 "href": asset_metadata.get(BatchJobs.ASSET_PUBLIC_HREF)
-                or _job_result_download_url(job_id, user_id, filename),
+                        or backend_implementation.config.asset_url.get(asset_metadata, filename, job_id, user_id),
                 "type": asset_metadata.get("type", asset_metadata.get("media_type", "application/octet-stream")),
                 "roles": asset_metadata.get("roles", ["data"]),
                 "raster:bands": asset_metadata.get("raster:bands"),

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1464,7 +1464,7 @@ def register_views_batch_jobs(
         for asset in assets.values():
             if not asset["href"].startswith("http"):
                 asset_file_name = pathlib.Path(asset["href"]).name
-                asset["href"] = backend_implementation.config.asset_url.get(asset, job_id, user_id, asset_file_name)
+                asset["href"] = backend_implementation.config.asset_url.get(asset, asset_file_name, job_id, user_id)
         stac_item = {
             "stac_version": ml_model_metadata.get("stac_version", "0.9.0"),
             "stac_extensions": ml_model_metadata.get("stac_extensions", []),

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1464,7 +1464,7 @@ def register_views_batch_jobs(
         for asset in assets.values():
             if not asset["href"].startswith("http"):
                 asset_file_name = pathlib.Path(asset["href"]).name
-                asset["href"] = backend_implementation.config.asset_url.get(asset_metadata=asset, asset_name=asset_file_name, job_id=job_id, user_id=user_id)
+                asset["href"] = backend_implementation.config.asset_url.build_url(asset_metadata=asset, asset_name=asset_file_name, job_id=job_id, user_id=user_id)
         stac_item = {
             "stac_version": ml_model_metadata.get("stac_version", "0.9.0"),
             "stac_extensions": ml_model_metadata.get("stac_extensions", []),
@@ -1486,7 +1486,7 @@ def register_views_batch_jobs(
             {
                 "title": asset_metadata.get("title", filename),
                 "href": asset_metadata.get(BatchJobs.ASSET_PUBLIC_HREF)
-                        or backend_implementation.config.asset_url.get(asset_metadata=asset_metadata, asset_name=filename, job_id=job_id, user_id=user_id),
+                        or backend_implementation.config.asset_url.build_url(asset_metadata=asset_metadata, asset_name=filename, job_id=job_id, user_id=user_id),
                 "type": asset_metadata.get("type", asset_metadata.get("media_type", "application/octet-stream")),
                 "roles": asset_metadata.get("roles", ["data"]),
                 "raster:bands": asset_metadata.get("raster:bands"),

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1486,7 +1486,7 @@ def register_views_batch_jobs(
             {
                 "title": asset_metadata.get("title", filename),
                 "href": asset_metadata.get(BatchJobs.ASSET_PUBLIC_HREF)
-                        or backend_implementation.config.asset_url.get(asset_metadata, filename, job_id, user_id),
+                        or backend_implementation.config.asset_url.get(asset_metadata=asset_metadata, asset_name=filename, job_id=job_id, user_id=user_id),
                 "type": asset_metadata.get("type", asset_metadata.get("media_type", "application/octet-stream")),
                 "roles": asset_metadata.get("roles", ["data"]),
                 "raster:bands": asset_metadata.get("raster:bands"),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -123,7 +123,7 @@ class DummyDirectS3Assets(AssetUrl):
         href = asset_metadata.get("href", "")
         if href.startswith("s3://"):
             return href.replace("s3://", f"{self.S3_ENDPOINT}/")
-        return super().build_url(asset_metadata, asset_name, job_id, user_id)
+        return super().build_url(asset_metadata=asset_metadata, asset_name=asset_name, job_id=job_id, user_id=user_id)
 
 
 def api_from_backend_implementation(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -190,7 +190,7 @@ class TestGeneral:
         ({"X-Forwarded-Proto": "https"}, "https://oeo.net/"),
     ])
     def test_https_proxy_handling(self, client, headers, expected):
-        resp = client.build_url('/.well-known/openeo', headers=headers)
+        resp = client.get('/.well-known/openeo', headers=headers)
         for url in [v["url"] for v in resp.json["versions"]]:
             assert url.startswith(expected)
 
@@ -207,7 +207,7 @@ class TestGeneral:
         ],
     )
     def test_versioned_urls(self, client, url, expected_version):
-        resp = client.build_url(url)
+        resp = client.get(url)
         assert resp.status_code == 200
         capabilities = resp.json
         assert capabilities["title"] == "Dummy openEO Backend"
@@ -238,7 +238,7 @@ class TestGeneral:
         assert get_link("conformance")["href"] == "http://oeo.net/openeo/1.0.0/conformance"
 
     def test_capabilities_invalid_api_version(self, client):
-        resp = ApiResponse(client.build_url('/openeo/0.0.0/'))
+        resp = ApiResponse(client.get('/openeo/0.0.0/'))
         resp.assert_error(501, 'UnsupportedApiVersion')
         assert "Unsupported version component in URL: '0.0.0'" in resp.json['message']
 
@@ -724,7 +724,7 @@ def oidc_provider(requests_mock):
     oidc_conf = f"{oidc_issuer}/.well-known/openid-configuration"
     oidc_userinfo_url = f"{oidc_issuer}/userinfo"
     oidc_introspection_url = f"{oidc_issuer}/token/inspect"
-    requests_mock.build_url(
+    requests_mock.get(
         oidc_conf,
         json={
             "userinfo_endpoint": oidc_userinfo_url,
@@ -751,7 +751,7 @@ def oidc_provider(requests_mock):
             context.status_code = 401
             return {"code": "InvalidToken"}
 
-    requests_mock.build_url(oidc_userinfo_url, json=userinfo)
+    requests_mock.get(oidc_userinfo_url, json=userinfo)
     requests_mock.post(oidc_introspection_url, json=introspection)
 
 
@@ -1419,7 +1419,7 @@ class TestBatchJobs:
         }
         if default_job_options is not None:
             process_definition["default_job_options"] = default_job_options
-        requests_mock.build_url("https://share.test/add3.json", json=process_definition)
+        requests_mock.get("https://share.test/add3.json", json=process_definition)
 
         pg = {
             "add12": {"process_id": "add", "arguments": {"x": 1, "y": 2}},

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1324,10 +1324,10 @@ class TestBatchJobs:
 
             if jobs:
                 for job_id, job_settings in jobs.items():
-                    key = (job_settings.build_url("user", TEST_USER), job_id)
+                    key = (job_settings.get("user", TEST_USER), job_id)
                     dummy_backend.DummyBatchJobs._job_registry[key] = BatchJobMetadata(
                         id=job_id,
-                        status=job_settings.build_url("status", "running"),
+                        status=job_settings.get("status", "running"),
                         process={'process_graph': {'foo': {'process_id': 'foo', 'arguments': {}}}},
                         created=datetime(2017, 1, 1, 9, 32, 12),
                     )


### PR DESCRIPTION
Group the logic where download urls are created for assets.

The default implementation is meant to be a backwards compatible refactor.

This change does allow backend implementations to implement custom behavior such that retrieval of the actual assets does not need to go via the driver.

Notes:

- Did not go for the option to have a base implementation without signer because then it is not really possible to add this change in a backwards compatible way because consumers that use signing now must then add the first override that supports signing so signing checking logic is part of the most basic implementation (with the downside of the ugly local import)
- Test coverage should ensure backwards compatibility as all original tests still exists. With parameterize there are additional test cases to show case that an alternative AssetUrl implementation could help generate URLs against a different endpoint/service where possible and still fallback to default behavior whenever it is not possible.