### PR TITLE
Write same message to log as the user will see for a sync job

### DIFF
--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -326,7 +326,7 @@ def register_error_handlers(app: flask.Flask, backend_implementation: OpenEoBack
         # TODO: is it possible to eliminate this custom summarize_exception/ErrorSummary handling?
         error = backend_implementation.summarize_exception(error)
         if isinstance(error, ErrorSummary):
-            log_message = repr(error.exception)
+            log_message = error.summary
             if error.is_client_error:
                 api_error = OpenEOApiException(message=error.summary, code="BadRequest", status_code=400)
             else:

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -308,9 +308,9 @@ def register_error_handlers(app: flask.Flask, backend_implementation: OpenEoBack
         ))
 
     @app.errorhandler(OpenEOApiException)
-    def handle_openeoapi_exception(error: OpenEOApiException):
+    def handle_openeoapi_exception(error: OpenEOApiException, log_message: Optional[str] = None):
         """Error handler for OpenEOApiException"""
-        _log.error(repr(error), exc_info=True)
+        _log.error(log_message or repr(error), exc_info=True)
         # most_recent_exception = sys.exc_info()[1]
         # fmt = Format(max_value_str_len=1000)
         # _log.error(
@@ -335,7 +335,7 @@ def register_error_handlers(app: flask.Flask, backend_implementation: OpenEoBack
             log_message = repr(error)
             api_error = InternalException(message=repr(error))
 
-        return handle_openeoapi_exception(api_error)
+        return handle_openeoapi_exception(api_error, log_message=log_message)
 
 def response_204_no_content():
     return make_response('', 204, {"Content-Type": "application/json"})

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -308,9 +308,9 @@ def register_error_handlers(app: flask.Flask, backend_implementation: OpenEoBack
         ))
 
     @app.errorhandler(OpenEOApiException)
-    def handle_openeoapi_exception(error: OpenEOApiException, log_message: Optional[str] = None):
+    def handle_openeoapi_exception(error: OpenEOApiException):
         """Error handler for OpenEOApiException"""
-        _log.error(log_message or repr(error), exc_info=True)
+        _log.error(repr(error), exc_info=True)
         # most_recent_exception = sys.exc_info()[1]
         # fmt = Format(max_value_str_len=1000)
         # _log.error(
@@ -335,7 +335,7 @@ def register_error_handlers(app: flask.Flask, backend_implementation: OpenEoBack
             log_message = repr(error)
             api_error = InternalException(message=repr(error))
 
-        return handle_openeoapi_exception(api_error, log_message=log_message)
+        return handle_openeoapi_exception(api_error)
 
 def response_204_no_content():
     return make_response('', 204, {"Content-Type": "application/json"})

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -406,13 +406,7 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                re_assert.Matches(
-                    re.escape(
-                        f"""InternalException(status_code=500, code='Internal', message="Server error: Exception('Computer says no.')", id='"""
-                    )
-                    + "r-[0-9a-f]{32}"
-                    + re.escape("')")
-                ),
+                "Exception('Computer says no.')",
             ),
         ]
 
@@ -431,13 +425,7 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                re_assert.Matches(
-                    re.escape(
-                        f"""InternalException(status_code=500, code='Internal', message='Server error: NotImplementedError()', id='"""
-                    )
-                    + "r-[0-9a-f]{32}"
-                    + re.escape("')")
-                ),
+                "NotImplementedError()",
             )
         ]
 
@@ -456,13 +444,7 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                re_assert.Matches(
-                    re.escape(
-                        f"""InternalException(status_code=500, code='Internal', message='Server error: No negatives please.', id='"""
-                    )
-                    + "r-[0-9a-f]{32}"
-                    + re.escape("')")
-                ),
+                "ValueError(-123)",
             )
         ]
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -444,7 +444,7 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                "ValueError(-123)",
+                "No negatives please.",
             )
         ]
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -406,7 +406,13 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                "Exception('Computer says no.')",
+                re_assert.Matches(
+                    re.escape(
+                        f"""InternalException(status_code=500, code='Internal', message="Server error: Exception('Computer says no.')", id='"""
+                    )
+                    + "r-[0-9a-f]{32}"
+                    + re.escape("')")
+                ),
             ),
         ]
 
@@ -425,7 +431,13 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                "NotImplementedError()",
+                re_assert.Matches(
+                    re.escape(
+                        f"""InternalException(status_code=500, code='Internal', message='Server error: NotImplementedError()', id='"""
+                    )
+                    + "r-[0-9a-f]{32}"
+                    + re.escape("')")
+                ),
             )
         ]
 
@@ -444,7 +456,13 @@ class TestGeneral:
             (
                 "openeo_driver.views.error",
                 logging.ERROR,
-                "ValueError(-123)",
+                re_assert.Matches(
+                    re.escape(
+                        f"""InternalException(status_code=500, code='Internal', message='Server error: No negatives please.', id='"""
+                    )
+                    + "r-[0-9a-f]{32}"
+                    + re.escape("')")
+                ),
             )
         ]
 


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/890#issuecomment-2837618676

@soxofaan The idea is that the messages that get logged in elasticsearch are not the same as the more user friendly messages that get shown to the user.

I think there is an other upside where there is more information in the logs with this. I'll craft an example...