### PR TITLE
fix: make sure lower is never called on None object

### DIFF
--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -890,7 +890,7 @@ def _s3_client(endpoint_url = os.environ.get("SWIFT_URL")):
     aws_access_key_id = os.environ.get("SWIFT_ACCESS_KEY_ID", os.environ.get("AWS_ACCESS_KEY_ID"))
     aws_secret_access_key = os.environ.get("SWIFT_SECRET_ACCESS_KEY", os.environ.get("AWS_SECRET_ACCESS_KEY"))
 
-    if "waw" in endpoint_url.lower():
+    if "waw" in (endpoint_url or "").lower():
         aws_access_key_id = os.environ.get("WAW31_ACCESS_KEY_ID", aws_access_key_id)
         aws_secret_access_key = os.environ.get("WAW31_SECRET_ACCESS_KEY", aws_secret_access_key)
 


### PR DESCRIPTION
The endpoint in the endpoint check can be None which results in "AttributeError: 'NoneType' object has no attribute 'lower'".