### PR TITLE
1111 return stac11 items

### DIFF
--- a/openeo_driver/backend.py
+++ b/openeo_driver/backend.py
@@ -442,6 +442,7 @@ class BatchJobMetadata(NamedTuple):
 class BatchJobResultMetadata:
     # Basic dataclass based wrapper for batch job result metadata (allows cleaner code navigation and discovery)
     assets: Dict[str, dict] = dataclasses.field(default_factory=dict)
+    items: Dict[str, dict] = dataclasses.field(default_factory=dict)
     links: List[dict] = dataclasses.field(default_factory=list)
     providers: List[dict] = dataclasses.field(default_factory=list)
     # TODO: more fields


### PR DESCRIPTION
https://github.com/Open-EO/openeo-geopyspark-driver/issues/1111

TODO:

- [ ] changelog entry
- [ ] based on example items dict below, construct a unit test, check if it returns valid STAC 1.1




Example item entry:

```
{
 "5d2db643-5cc3-4b27-8ef3-11f7d203b221_2023-12-31T21:41:00Z": {
      "geometry": {
        "coordinates": [
          [
            [
              3.359808992021044,
              51.08284561357965
            ],
            [
              3.359808992021044,
              51.88641704215104
            ],
            [
              4.690166134878123,
              51.88641704215104
            ],
            [
              4.690166134878123,
              51.08284561357965
            ],
            [
              3.359808992021044,
              51.08284561357965
            ]
          ]
        ],
        "type": "Polygon"
      },
      "assets": {
        "openEO": {
          "datetime": "2023-12-31T21:41:00Z",
          "roles": [
            "data"
          ],
          "bbox": [
            3.359808992021044,
            51.08284561357965,
            4.690166134878123,
            51.88641704215104
          ],
          "geometry": {
            "coordinates": [
              [
                [
                  3.359808992021044,
                  51.08284561357965
                ],
                [
                  3.359808992021044,
                  51.88641704215104
                ],
                [
                  4.690166134878123,
                  51.88641704215104
                ],
                [
                  4.690166134878123,
                  51.08284561357965
                ],
                [
                  3.359808992021044,
                  51.08284561357965
                ]
              ]
            ],
            "type": "Polygon"
          },
          "href": "s3://openeo-data-staging-waw4-1/batch_jobs/j-250605095828442799fdde3c29b5b047/openEO_20231231T214100Z.tif",
          "nodata": "nan",
          "type": "image/tiff; application=geotiff",
          "bands": [
            {
              "name": "LST",
              "common_name": "surface_temperature",
              "aliases": [
                "LST_in:LST"
              ]
            }
          ],
          "raster:bands": [
            {
              "name": "LST",
              "statistics": {
                "valid_percent": 66.88,
                "maximum": 281.04800415039,
                "stddev": 19.598456945276,
                "minimum": 224.46798706055,
                "mean": 259.57087672984
              }
            }
          ]
        }
      },
      "id": "5d2db643-5cc3-4b27-8ef3-11f7d203b221_2023-12-31T21:41:00Z",
      "properties": {
        "datetime": "2023-12-31T21:41:00Z"
      },
      "bbox": [
        3.359808992021044,
        51.08284561357965,
        4.690166134878123,
        51.88641704215104
      ]
    }
}
```