### PR TITLE
Match env parameter name for query_stac

### DIFF
--- a/openeo_driver/backend.py
+++ b/openeo_driver/backend.py
@@ -986,7 +986,7 @@ class OpenEoBackendImplementation:
     def load_stac(self, url: str, load_params: LoadParameters, env: EvalEnv) -> DriverDataCube:
         raise NotImplementedError
 
-    def query_stac(self, url: str, spatial_extent: Union[Dict, BoundingBox, None], temporal_extent: Tuple[Optional[str], Optional[str]], _env: EvalEnv) -> DriverDataCube:
+    def query_stac(self, url: str, spatial_extent: Union[Dict, BoundingBox, None], temporal_extent: Tuple[Optional[str], Optional[str]], env: EvalEnv) -> DriverDataCube:
         raise NotImplementedError
 
     def load_ml_model(self, job_id: str) -> DriverMlModel:


### PR DESCRIPTION
Fixes a typo from #480 