### PR TITLE
Make _list_job_results use a copy of links to avoid modifying it.

### DIFF
--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1138,7 +1138,7 @@ def register_views_batch_jobs(
         #   This is a bit of an ugly temporary hack, to aid in testing and comparing.
         TREAT_JOB_RESULTS_V100_LIKE_V110 = smart_bool(os.environ.get("TREAT_JOB_RESULTS_V100_LIKE_V110", "0"))
 
-        links: List[dict] = list(result_metadata.links or job_info.links or [])
+        links: List[dict] = [dict(l) for l in (result_metadata.links or job_info.links or [])]
 
         try:
             # TODO: Cleanup

--- a/openeo_driver/views.py
+++ b/openeo_driver/views.py
@@ -1138,7 +1138,7 @@ def register_views_batch_jobs(
         #   This is a bit of an ugly temporary hack, to aid in testing and comparing.
         TREAT_JOB_RESULTS_V100_LIKE_V110 = smart_bool(os.environ.get("TREAT_JOB_RESULTS_V100_LIKE_V110", "0"))
 
-        links: List[dict] = [dict(l) for l in (result_metadata.links or job_info.links or [])]
+        links: List[dict] = copy.deepcopy(result_metadata.links or job_info.links or [])
 
         try:
             # TODO: Cleanup


### PR DESCRIPTION
Refreshing [this url](https://openeo-staging.dataspace.copernicus.eu/openeo/1.2/jobs/j-2605191821484b2ab564f07965b92f40/results/ODlhOWM4NjgtY2M0NC00NmJiLTkyMjktMTVmZjdmMjk4NWNm/3d9aa9b5a6bb78c03f3976b51dd02ebd?expires=1781001231) always makes the original url link longer.
This mr attempts to fix that by making a deeper copy of the links list.
```json
{
"href": "https://openeo-staging.dataspace.copernicus.eu/openeo/1.2/jobs/j-2605191821484b2ab564f07965b92f40/results/assets/collection.json%3Fuser_base64=ODlhOWM4NjgtY2M0NC00NmJiLTkyMjktMTVmZjdmMjk4NWNm&expires=1781001231&secure_key=3d9aa9b5a6bb78c03f3976b51dd02ebd?user_base64=ODlhOWM4NjgtY2M0NC00NmJiLTkyMjktMTVmZjdmMjk4NWNm&expires=1781001234&secure_key=b3d3c2379b2f520b52cec862f2e4b03e",
"rel": "original",
"title": "Link to original STAC catalog.",
"type": "application/json"
},
```
```json
{
"href": "https://openeo-staging.dataspace.copernicus.eu/openeo/1.2/jobs/j-2605191821484b2ab564f07965b92f40/results/assets/collection.json%253Fuser_base64=ODlhOWM4NjgtY2M0NC00NmJiLTkyMjktMTVmZjdmMjk4NWNm&expires=1781001231&secure_key=3d9aa9b5a6bb78c03f3976b51dd02ebd%3Fuser_base64=ODlhOWM4NjgtY2M0NC00NmJiLTkyMjktMTVmZjdmMjk4NWNm&expires=1781001234&secure_key=b3d3c2379b2f520b52cec862f2e4b03e?user_base64=ODlhOWM4NjgtY2M0NC00NmJiLTkyMjktMTVmZjdmMjk4NWNm&expires=1781001248&secure_key=1635389b0c586e80bfdc6bb4850b53b1",
"rel": "original",
"title": "Link to original STAC catalog.",
"type": "application/json"
},
```
@copilot review