### PR TITLE
Add check-illegal-windows-names to avoid accidentally commiting files with ":" in the name.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,6 +11,7 @@ repos:
       - id: check-json
       - id: check-yaml
       - id: check-toml
+      - id: check-illegal-windows-names
   - repo: https://github.com/akaihola/darker
     rev: 1.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
```bash
touch "test:test"
git add test:test
git commit -m "test:test"
check illegal windows names..............................................Failed
- hook id: check-illegal-windows-names
- exit code: 1

Illegal Windows filenames detected
```