### PR TITLE
Feature id property csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and start a new "In Progress" section above it.
 - Support logging added value for synchronous requests ([Open-EO/openeo-geopyspark-driver#1436](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1436))
 - Add caching to `BoundingBox` CRS handling and reprojection for performance optimization of bounding box merging in post-dry-run of openeo-geopyspark-driver ([Open-EO/openeo-geopyspark-driver#1685](https://github.com/Open-EO/openeo-geopyspark-driver/issues/1685))
 - Add cache class `BoundedTtlCache` to replace `TtlCache` ([#509](https://github.com/Open-EO/openeo-python-driver/pull/509))
+- Allow `feature_id_property` to add an extra column to CSV output. ([#524](https://github.com/Open-EO/openeo-python-driver/issues/524))
 
 ## 0.139.0
 

--- a/openeo_driver/save_result.py
+++ b/openeo_driver/save_result.py
@@ -842,10 +842,9 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
 
             if id_mapping is not None:
                 df = pd.read_csv(destination)
-                if "feature_index" in df.columns:
-                    column_name = self._feature_id_column_name()
-                    df[column_name] = df["feature_index"].map(id_mapping)
-                    df.to_csv(destination, index=False)
+                column_name = self._feature_id_column_name()
+                df[column_name] = df["feature_index"].map(id_mapping)
+                df.to_csv(destination, index=False)
 
             return destination
 

--- a/openeo_driver/save_result.py
+++ b/openeo_driver/save_result.py
@@ -781,6 +781,25 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
             return self.to_covjson()
         return self.data
 
+    def _feature_id_mapping(self) -> Optional[dict]:
+        feature_id_property = self._feature_id_column_name()
+        if not isinstance(self._regions, DriverVectorCube):
+            _log.warning(
+                f"save_result: 'feature_id_property' was specified, but regions are not a DriverVectorCube ({type(self._regions)})."
+            )
+            return None
+        values = self._regions.get_band_values(feature_id_property)
+        if values is None:
+            _log.warning(
+                f"save_result: a feature_id_property '{feature_id_property}' was specified,"
+                f" but could not find it in the vector cube: {self._regions}."
+            )
+            return None
+        return dict(enumerate(values))
+
+    def _feature_id_column_name(self) -> str:
+        return self.options.get("feature_id_property", "id")
+
     def to_csv(self, destination=None):
         csv_paths = glob.glob(self._csv_dir + "/*.csv")
 
@@ -788,7 +807,9 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
             _log.warning(f"save_result: no csv files found at expected location: {self._csv_dir}")
             return
 
-        if(len(csv_paths) == 1):
+        id_mapping = self._feature_id_mapping()
+
+        if len(csv_paths) == 1 and id_mapping is None:
             if(destination == None):
                 return csv_paths[0]
             else:
@@ -815,6 +836,15 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
                 first_file = False
 
             f.close()
+
+            if id_mapping is not None:
+                df = pd.read_csv(destination)
+                if "feature_index" in df.columns:
+                    column_name = self._feature_id_column_name()
+                    df[column_name] = df["feature_index"].map(id_mapping)
+                    df.to_csv(destination, index=False)
+
+            return destination
 
 
 class AggregatePolygonSpatialResult(SaveResult):

--- a/openeo_driver/save_result.py
+++ b/openeo_driver/save_result.py
@@ -783,6 +783,9 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
 
     def _feature_id_mapping(self) -> Optional[dict]:
         feature_id_property = self._feature_id_column_name()
+        if not feature_id_property:
+            # Use this by default to not change anything to existing CSV outputs.
+            return None
         if not isinstance(self._regions, DriverVectorCube):
             _log.warning(
                 f"save_result: 'feature_id_property' was specified, but regions are not a DriverVectorCube ({type(self._regions)})."
@@ -797,10 +800,10 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
             return None
         return dict(enumerate(values))
 
-    def _feature_id_column_name(self) -> str:
-        return self.options.get("feature_id_property", "id")
+    def _feature_id_column_name(self) -> Optional[str]:
+        return self.options.get("feature_id_property")  # default would be "id"
 
-    def to_csv(self, destination=None):
+    def to_csv(self, destination: Union[str, Path, None] = None) -> Union[str, Path, None]:
         csv_paths = glob.glob(self._csv_dir + "/*.csv")
 
         if(len(csv_paths) == 0):

--- a/openeo_driver/save_result.py
+++ b/openeo_driver/save_result.py
@@ -801,7 +801,8 @@ class AggregatePolygonResultCSV(AggregatePolygonResult):
         return dict(enumerate(values))
 
     def _feature_id_column_name(self) -> Optional[str]:
-        return self.options.get("feature_id_property")  # default would be "id"
+        # default would be "id" if the feature needs to be enabled by default
+        return self.options.get("feature_id_property")
 
     def to_csv(self, destination: Union[str, Path, None] = None) -> Union[str, Path, None]:
         csv_paths = glob.glob(self._csv_dir + "/*.csv")

--- a/tests/test_save_result_csv.py
+++ b/tests/test_save_result_csv.py
@@ -142,7 +142,7 @@ def test_aggregate_polygon_result_csv_feature_id_property(tmp_path):
     result.set_format("csv", options={"feature_id_property": "id"})
 
     filename = result.to_csv(tmp_path / "timeseries_feature_id.csv")
-
+    assert filename
     actual_df = pd.read_csv(filename)
     assert "id" in actual_df.columns
     assert set(actual_df["id"].dropna()) == {"f_north", "f_south"}

--- a/tests/test_save_result_csv.py
+++ b/tests/test_save_result_csv.py
@@ -122,3 +122,29 @@ def test_write_driver_vector_cube_to_csv(tmp_path):
 
     actual_gdf = pd.read_csv(tmp_path / "vectorcube.csv")
     assert actual_gdf.shape == (2, 4)
+
+
+def test_aggregate_polygon_result_csv_feature_id_property(tmp_path):
+    """`feature_id_property` option should replace `feature_index` with the requested feature property."""
+    regions = DriverVectorCube.from_geojson({
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "properties": {"id": "f_north"}, "geometry": Polygon([(0, 0), (5, 1), (1, 4)]).__geo_interface__},
+            {"type": "Feature", "properties": {"id": "f_middle"}, "geometry": Polygon([(6, 1), (1, 7), (9, 9)]).__geo_interface__},
+            {"type": "Feature", "properties": {"id": "f_south"}, "geometry": Polygon([(6, 1), (1, 7), (9, 9)]).__geo_interface__},
+        ],
+    })
+
+    result = AggregatePolygonResultCSV(
+        csv_dir=str(Path(__file__).parent / "data" / "aggregate_spatial_spacetime_cube"),
+        regions=regions,
+    )
+    result.set_format("csv", options={"feature_id_property": "id"})
+
+    filename = result.to_csv(tmp_path / "timeseries_feature_id.csv")
+
+    actual_df = pd.read_csv(filename)
+    assert "id" in actual_df.columns
+    assert set(actual_df["id"].dropna()) == {"f_north", "f_south"}
+    # feature_index 1 (f_middle) is not present in the source CSVs
+    assert "f_middle" not in set(actual_df["id"].dropna())

--- a/tests/test_save_result_csv.py
+++ b/tests/test_save_result_csv.py
@@ -1,10 +1,12 @@
+from pathlib import Path
+
 import pandas as pd
 import pytest
 from numpy import nan
 from shapely.geometry import GeometryCollection, Polygon
 
 from openeo_driver.datacube import DriverVectorCube
-from openeo_driver.save_result import AggregatePolygonResult
+from openeo_driver.save_result import AggregatePolygonResult, AggregatePolygonResultCSV
 from .data import get_path
 
 

--- a/tests/test_save_result_csv.py
+++ b/tests/test_save_result_csv.py
@@ -147,4 +147,3 @@ def test_aggregate_polygon_result_csv_feature_id_property(tmp_path):
     assert "id" in actual_df.columns
     assert set(actual_df["id"].dropna()) == {"f_north", "f_south"}
     # feature_index 1 (f_middle) is not present in the source CSVs
-    assert "f_middle" not in set(actual_df["id"].dropna())


### PR DESCRIPTION
Now when adding `feature_id_property` to the `save_result`, it adds a column with the feature id. Just like parquet.
@soxofaan I disabled adding this column by default, for backwards compatibility, even tough no test failed on it. Ok for you?

<img width="1004" height="360" alt="image" src="https://github.com/user-attachments/assets/de2afa52-3bcf-475a-a4ed-53bfb31616b5" />
<img width="1323" height="360" alt="image" src="https://github.com/user-attachments/assets/3a7e4a84-60ed-4da6-9abc-c41cbeda0e0e" />

https://github.com/Open-EO/openeo-python-driver/issues/524